### PR TITLE
改行文字("\n")は青空文庫フォーマットで使用しているためtrimしないよう修正

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -30,7 +30,7 @@ gulp.task 'watch', ->
 
 parse = ->
   through.obj (file, encoding, callback) ->
-    result = parser.parse file.contents.toString().trim("\n")
+    result = parser.parse file.contents.toString()
     file.contents = new Buffer JSON.stringify result
     @push file
     callback()


### PR DESCRIPTION
`.trim("\n")`をしてしまうともろもろまずそうでした…。
