### PR TITLE
本文のparserとして動作するよう修正

### DIFF
--- a/aozora-parser.pegjs
+++ b/aozora-parser.pegjs
@@ -9,6 +9,9 @@
  * 青空文庫の「文字」の表記法
  */
 
+Start
+  = Block+
+
 String
   = Char+
 
@@ -62,9 +65,9 @@ LatinChar "欧文字"
 
 GeneralString "一般文字列"
   = (
-    (String / LatinString) QuoteAnn* GeneralRuby? QuoteAnn*
-    / DefRuby QuoteAnn*
-  )+
+      ((String / LatinString) QuoteAnn* GeneralRuby? QuoteAnn*)
+      / (DefRuby QuoteAnn*)
+    )+
 
 AnnString "注記文字列"
   = (!"］" Char)+
@@ -76,7 +79,7 @@ QuoteString "引用文字列"
   )+
 
 QuoteChar "引用文字"
-  = (!"」は" !"」の" !"」に" !"」］" String)+
+  = !"」は" !"」の" !"」に" !"」］" Char
 
 QuoteAnn "引用注記"
   = ModifierAnn


### PR DESCRIPTION
- Startを追加
- 一般文字列のカッコが省略されていたのを修正
- 引用文字の定義がgreedすぎた&&文字列になっていたのを文字として修正

これと先ほどのPRを合わせると、本文のみの青空文庫についてはparseできるかもです（sorekara-yokokku.txtはヘッダとフッタを消すと通りました）
